### PR TITLE
add $databases parameter to ::influxdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ class { '::influxdb':
       'read-buffer'   => 33554432,
     },
   },
+  databases      => {
+    prometheus => {
+      ensure => present,
+    },
+  },
 }
 
 influxdb::database { 'metrics': }
@@ -46,7 +51,7 @@ influxdb::user { 'grafana_user':
 ```
 
 # http auth
-http_auth is automatically enabled and configured.
+http\_auth is automatically enabled and configured.
 
 An admin account will automatically be created with the parameters passed to the main class: `influxdb::admin_username` and `influxdb::admin_password`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,12 @@
 #           'max-series-per-database' => 0,
 #           'max-values-per-tag'      => 0,
 #         }
-#       }
+#       },
+#       databases      => {
+#         prometheus => {
+#           ensure => present,
+#         },
+#       },
 #     }
 #
 # @param ensure         - Whether to create or destroy this resource
@@ -30,6 +35,8 @@
 # @param config_path    - The path to the main configuration file
 # @param group          - The group used for permission on for everything
 # @param owner          - The owner used for permission on for everything
+# @param databases      - Create the provided databases. The hash is passed on to infludb::database
+#                         via create_resources()
 #
 class influxdb (
   String $admin_password,
@@ -42,6 +49,8 @@ class influxdb (
   String                   $config_path    = '/etc/influxdb/influxdb.conf',
   String                   $group          = 'influxdb',
   String                   $owner          = 'influxdb',
+
+  Hash[String, Hash[String, Any]] $databases = {},
 ) {
 
   if ($ensure_package == undef and $ensure == 'present') {
@@ -75,4 +84,6 @@ class influxdb (
     admin_username => $admin_username,
     config_path    => $config_path,
   }
+
+  create_resources('influxdb::database', $databases)
 }


### PR DESCRIPTION
I would like to propose adding a `influxdb::databases` parameter, that can be used to pass the managed databases directly to the main-class without calling `influxdb::database` individually.

It would make the interaction with _hiera_ easier, allowing you to declare the databases directly there without having to create Puppet-code for calling `influxdb::database`. There then a simple `include ::influxdb` would be enough. The rest can be specified in _hiera_.

e.g.

```yaml
influxdb::configuration:
  data:
    dir: /data/influxdb/data
    wal-dir: /data/influxdb/wal
    max-series-per-database: 0
    max-values-per-tag: 0
    query-log-enabled: false
  logging:
    level: warn
  http:
    log-enabled: false
influxdb::databases:
  prometheus:
    ensure: present
  test:
    ensure: absent
```