### PR TITLE
adapt reading privileges from InfluxDB grants in case of ALL-PRIVILEGES

### DIFF
--- a/lib/puppet/provider/influxdb_user/influxdb_user.rb
+++ b/lib/puppet/provider/influxdb_user/influxdb_user.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:influxdb_user).provide(:user_management) do
 
     return 'ALL' if is_admin
 
-    JSON.parse(influx_cli("SHOW GRANTS FOR \"#{resource[:username]}\""))['results'][0]['series'][0]['values'].to_h[resource[:database]]
+    JSON.parse(influx_cli("SHOW GRANTS FOR \"#{resource[:username]}\""))['results'][0]['series'][0]['values'].to_h[resource[:database]].gsub('ALL PRIVILEGES', 'ALL')
   end
 
   def privilege=(value)


### PR DESCRIPTION
I don't know if this was the case with older _InfluxDB_ versions too, but at least with _InfluxDB_ `v1.7.10` _puppet-influxdb_ keeps notifying me about adapting the `ALL` privilege of an user on a specific database on every run.

e.g. I have the following user declared

```
influxdb::influxdb_user { 'someuser':
  password => 'superSecret',
  database => 'somedb',
  privileges => 'ALL', ;
}
```
Then beginning with the 2nd run - after the initial privilege was set - Puppet notifies about:

```
Notice: /Stage[main]/Profile::Influxdb/Influxdb::User[someuser]/Influxdb_user[influxdb_user_someuser]/privilege: privilege changed 'ALL PRIVILEGES' to 'ALL'
```

what is actually correct as _InfluxDB_ reports the privilege as `ALL PRIVILEGES`:

```
> show grants for "someuser"
database   privilege
--------   ---------
somedb ALL PRIVILEGES
```

So I've fixed it with a simple search & replace in the `influxdb_user` _provider_.

But not sure if it is the right way for you to tackle it :)